### PR TITLE
Fix missing hydra require in elcontext-time

### DIFF
--- a/elcontext-time.el
+++ b/elcontext-time.el
@@ -27,6 +27,7 @@
 (require 'ht)
 (require 'dash)
 (require 's)
+(require 'hydra)
 (require 'elcontext-utils)
 
 (defun elcontext-time--date-to-calendardate (date)


### PR DESCRIPTION
In elcontext-time.el, there is an hydra definition but the library is not loaded. This can cause trouble when loading the package and hydra is not yet activated.